### PR TITLE
Output full records to GCS

### DIFF
--- a/src/main/java/com/google/changestreams/sample/Main.java
+++ b/src/main/java/com/google/changestreams/sample/Main.java
@@ -80,7 +80,7 @@ public class Main {
         // Maps records to strings (commit timestamp only)
         .apply(MapElements
             .into(TypeDescriptors.strings())
-            .via(record -> record.getCommitTimestamp().toString())
+            .via(record -> record.toString())
         )
 
         // Group records into 1 minute windows


### PR DESCRIPTION
Previously it was just commit timestamp, but it's not as straightforward as a sample.