### PR TITLE
Add sample code for BigQuery full row replication to changelog table

### DIFF
--- a/run_bigquery.sh
+++ b/run_bigquery.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -e
+
+function print_usage() {
+  cat <<EOF
+Usage: ./run.sh
+  -p <project>
+  -i <instance>
+  -d <database>
+  -mi <metadata instance>
+  -md <metadata database>
+  -c <change stream name>
+  -g <gcs bucket>
+  -r <job region>
+  -bd <BigQuery dataset>
+  -bt <BigQuery table name>
+EOF
+  exit
+}
+
+if ! command -v mvn &>/dev/null; then
+	cat <<EOF
+Please install Maven!
+Linux:  sudo apt install -y maven
+Mac:  brew install maven
+EOF
+	exit
+fi
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -p|--project)
+      PROJECT="$2"
+      shift
+      shift
+      ;;
+    -i|--instance)
+      INSTANCE="$2"
+      shift
+      shift
+      ;;
+    -d|--database)
+      DATABASE="$2"
+      shift
+      shift
+      ;;
+    -mi|--metadata-instance)
+      METADATA_INSTANCE="$2"
+      shift
+      shift
+      ;;
+    -md|--metadata-database)
+      METADATA_DATABASE="$2"
+      shift
+      shift
+      ;;
+    -c|--change-stream-name)
+      CHANGE_STREAM_NAME="$2"
+      shift
+      shift
+      ;;
+    -g|--gcs-bucket)
+      GCS_BUCKET="$2"
+      shift
+      shift
+      ;;
+    -r|--region)
+      REGION="$2"
+      shift
+      shift
+      ;;
+    -bd|--big-query-dataset)
+      BIG_QUERY_DATASET="$2"
+      shift
+      shift
+      ;;
+    -bt|--big-query-table-name)
+      BIG_QUERY_TABLE_NAME="$2"
+      shift
+      shift
+      ;;
+  *)
+    echo "Unknown option $1"
+    print_usage
+    ;;
+  esac
+done
+
+test ! "${PROJECT}" && echo "Missing project" && print_usage
+test ! "${INSTANCE}" && echo "Missing instance" && print_usage
+test ! "${DATABASE}" && echo "Missing database" && print_usage
+test ! "${METADATA_INSTANCE}" && echo "Missing metadata-instance" && print_usage
+test ! "${METADATA_DATABASE}" && echo "Missing metadata-database" && print_usage
+test ! "${CHANGE_STREAM_NAME}" && echo "Missing change-stream-name" && print_usage
+test ! "${GCS_BUCKET}" && echo "Missing gcs-bucket" && print_usage
+test ! "${REGION}" && echo "Missing region" && print_usage
+
+mvn \
+  clean \
+  compile \
+  exec:java -Dexec.mainClass=com.google.changestreams.sample.bigquery.Main \
+  -Dexec.args=" \
+    --project=${PROJECT} \
+    --instance=${INSTANCE} \
+    --database=${DATABASE} \
+    --metadataInstance=${METADATA_INSTANCE} \
+    --metadataDatabase=${METADATA_DATABASE} \
+    --changeStreamName=${CHANGE_STREAM_NAME} \
+    --gcsBucket=${GCS_BUCKET} \
+    --gcpTempLocation=gs://${GCS_BUCKET}/temp \
+    --region=${REGION} \
+    --bigQueryDataset=${BIG_QUERY_DATASET} \
+    --bigQueryTableName=${BIG_QUERY_TABLE_NAME} \
+    --runner=DataflowRunner \
+    --numWorkers=1 \
+    --maxNumWorkers=1 \
+    --experiments=use_unified_worker,use_runner_v2 \
+  "

--- a/src/main/java/com/google/changestreams/sample/SampleOptions.java
+++ b/src/main/java/com/google/changestreams/sample/SampleOptions.java
@@ -43,4 +43,12 @@ public interface SampleOptions extends DataflowPipelineOptions {
   String getGcsBucket();
 
   void setGcsBucket(String gcsBucket);
+
+  String getBigQueryDataset();
+
+  void setBigQueryDataset(String bigQueryDataset);
+
+  String getBigQueryTableName();
+
+  void setBigQueryTableName(String bigQueryTableName);
 }

--- a/src/main/java/com/google/changestreams/sample/bigquery/Main.java
+++ b/src/main/java/com/google/changestreams/sample/bigquery/Main.java
@@ -1,0 +1,234 @@
+package com.google.changestreams.sample.bigquery;
+
+import static org.apache.beam.runners.core.construction.resources.PipelineResources.detectClassPathResourcesToStage;
+
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.changestreams.sample.SampleOptions;
+import com.google.cloud.Timestamp;
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.cloud.spanner.*;
+import org.apache.avro.reflect.AvroEncode;
+import org.apache.beam.runners.dataflow.DataflowRunner;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
+import org.apache.beam.sdk.io.gcp.spanner.cdc.TimestampEncoding;
+import org.apache.beam.sdk.io.gcp.spanner.cdc.model.DataChangeRecord;
+import org.apache.beam.sdk.io.gcp.spanner.cdc.model.Mod;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.json.*;
+
+public class Main {
+  // Fields of BigQuery changelog table.
+  private static final String BQ_SCHEMA_NAME_SINGER_ID = "singer_id";
+  private static final String BQ_SCHEMA_NAME_FIRST_NAME = "first_name";
+  private static final String BQ_SCHEMA_NAME_LAST_NAME = "last_name";
+  private static final String BQ_SCHEMA_NAME_MOD_TYPE = "mod_type";
+  private static final String BQ_SCHEMA_NAME_SPANNER_COMMIT_TIMESTAMP = "spanner_commit_timestamp";
+  private static final String BQ_SCHEMA_NAME_BQ_COMMIT_TIMESTAMP = "bq_commit_timestamp";
+
+  public static void main(String[] args) {
+
+    final SampleOptions options = PipelineOptionsFactory
+      .fromArgs(args)
+      .as(SampleOptions.class);
+
+    options.setFilesToStage(deduplicateFilesToStage(options));
+    options.setEnableStreamingEngine(true);
+    options.setStreaming(true);
+
+    final Pipeline pipeline = Pipeline.create(options);
+
+    String projectId = options.getProject();
+    String instanceId = options.getInstance();
+    String databaseId = options.getDatabase();
+    String metadataInstanceId = options.getMetadataInstance();
+    String metadataDatabaseId = options.getMetadataDatabase();
+    String changeStreamName = options.getChangeStreamName();
+    String bigQueryDataset = options.getBigQueryDataset();
+    String bigQueryTableName = options.getBigQueryTableName();
+
+    final String bigQueryTable = String
+      .format("%s:%s.%s", projectId, bigQueryDataset, bigQueryTableName);
+
+    final Timestamp now = Timestamp.now();
+    final Timestamp after1Hour = Timestamp.ofTimeSecondsAndNanos(
+      now.getSeconds() + (60 * 60),
+      now.getNanos()
+    );
+
+    pipeline
+      // Read from the change stream.
+      .apply("Read from change stream",
+        SpannerIO
+        .readChangeStream()
+        .withSpannerConfig(SpannerConfig
+          .create()
+          .withProjectId(projectId)
+          .withInstanceId(instanceId)
+          .withDatabaseId(databaseId)
+        )
+        .withMetadataInstance(metadataInstanceId)
+        .withMetadataDatabase(metadataDatabaseId)
+        .withChangeStreamName(changeStreamName)
+        .withInclusiveStartAt(now)
+        .withInclusiveEndAt(after1Hour)
+      )
+
+      // Converts DataChangeRecord to SingerRow, each DataChangeRecord may contain
+      // multiple SingerRow, since it has multiple Mod.
+      .apply(ParDo.of(new ChangeRecordToSingersFn()))
+
+      // Writes SingerRow into BigQuery changelog table.
+      .apply("Write to BigQuery changelog table",
+        BigQueryIO
+          .<SingerRow>write()
+          .to(bigQueryTable)
+          // Use streaming insert, note streaming insert also provides instance data availability
+          // for query (not for DML).
+          .withMethod(Write.Method.STREAMING_INSERTS)
+          .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+          .withWriteDisposition(Write.WriteDisposition.WRITE_APPEND)
+          .withSchema(createSchema())
+          .withAutoSharding()
+          .optimizedWrites()
+          .withFormatFunction((SingerRow s) -> {
+              return new TableRow()
+                .set(BQ_SCHEMA_NAME_SINGER_ID, s.singerId)
+                .set(BQ_SCHEMA_NAME_FIRST_NAME, s.firstName)
+                .set(BQ_SCHEMA_NAME_LAST_NAME, s.lastName)
+                .set(BQ_SCHEMA_NAME_MOD_TYPE, s.modType)
+                .set(BQ_SCHEMA_NAME_SPANNER_COMMIT_TIMESTAMP, s.commitTimestamp.getSeconds())
+                // When using "AUTO", BigQuery will automatically populate the commit timestamp.
+                .set(BQ_SCHEMA_NAME_BQ_COMMIT_TIMESTAMP, "AUTO");
+            }
+          )
+      );
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  private static TableSchema createSchema() {
+    return new TableSchema().setFields(
+      Arrays.asList(
+        new TableFieldSchema()
+          .setName(BQ_SCHEMA_NAME_SINGER_ID)
+          .setType("INT64")
+          .setMode("REQUIRED"),
+        new TableFieldSchema()
+          .setName(BQ_SCHEMA_NAME_FIRST_NAME)
+          .setType("STRING")
+          .setMode("NULLABLE"),
+        new TableFieldSchema()
+          .setName(BQ_SCHEMA_NAME_LAST_NAME)
+          .setType("STRING")
+          .setMode("NULLABLE"),
+        new TableFieldSchema()
+          .setName(BQ_SCHEMA_NAME_MOD_TYPE)
+          .setType("STRING")
+          .setMode("REQUIRED"),
+        new TableFieldSchema()
+          .setName(BQ_SCHEMA_NAME_SPANNER_COMMIT_TIMESTAMP)
+          .setType("TIMESTAMP")
+          .setMode("REQUIRED"),
+        new TableFieldSchema()
+          .setName(BQ_SCHEMA_NAME_BQ_COMMIT_TIMESTAMP)
+          .setType("TIMESTAMP")
+          .setMode("REQUIRED")
+      )
+    );
+  }
+
+  @DefaultCoder(AvroCoder.class)
+  static class SingerRow implements Serializable {
+    public int singerId;
+    @AvroEncode(
+      using = TimestampEncoding.class
+    )
+    com.google.cloud.Timestamp commitTimestamp;
+    public String firstName, lastName, modType;
+  }
+
+  static class ChangeRecordToSingersFn extends DoFn<DataChangeRecord, SingerRow> {
+    @ProcessElement public void process(@Element DataChangeRecord element,
+                                        OutputReceiver<SingerRow> out,
+                                        ProcessContext c) {
+      SampleOptions ops = c.getPipelineOptions().as(SampleOptions.class);
+      Spanner spanner =
+        SpannerOptions.newBuilder()
+          .setProjectId(ops.getProject())
+          .build()
+          .getService();
+      DatabaseClient databaseClient = spanner
+        .getDatabaseClient(DatabaseId.of(ops.getProject(), ops.getInstance(), ops.getDatabase()));
+
+      String modType = element.getModType().toString();
+      com.google.cloud.Timestamp commitTimestamp = element.getCommitTimestamp();
+      for (Mod mod : element.getMods()) {
+        SingerRow s = new SingerRow();
+        s.commitTimestamp = commitTimestamp;
+        s.modType = modType;
+        JSONObject json = new JSONObject(mod.getKeysJson());
+        int singerId = json.getInt("SingerId");
+        s.singerId = singerId;
+        try (ResultSet resultSet =
+               databaseClient
+                 .singleUse()
+                 .read(
+                   "Singers",
+                   KeySet.singleKey(com.google.cloud.spanner.Key.of(singerId)),
+                   Arrays.asList("FirstName", "LastName"))) {
+
+          // We will only receive one row.
+          while (resultSet.next()) {
+            s.firstName = resultSet.getString("FirstName");
+            s.lastName = resultSet.getString("LastName");
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+
+        out.output(s);
+      }
+
+      spanner.close();
+    }
+  }
+
+  /**
+   * This is to avoid a bug in Dataflow, where if there are duplicate jar files to stage, the job
+   * gets stuck. Before submitting the job we deduplicate the jar files here.
+   */
+  private static List<String> deduplicateFilesToStage(DataflowPipelineOptions options) {
+    final Map<String, String> fileNameToPath = new HashMap<>();
+    final List<String> filePaths =
+      detectClassPathResourcesToStage(DataflowRunner.class.getClassLoader(), options);
+
+    for (String filePath : filePaths) {
+      final File file = new File(filePath);
+      final String fileName = file.getName();
+      if (!fileNameToPath.containsKey(fileName)) {
+        fileNameToPath.put(fileName, filePath);
+      }
+    }
+
+    return new ArrayList<>(fileNameToPath.values());
+  }
+}


### PR DESCRIPTION
This PR gives a sample of:
1. Read change records from change stream IO connector.
2. Convert each record into a SingerRow (the schema is fixed).
3. Write each SingerRow into BigQuery changelog table using BigQueryIO with streaming insert.

NOTE: This is ongoing work, DO NOT MERGE.

Example usage:

To run the pipeline (assume you have set up the change stream connectors):

```
./run_bigquery.sh \
  --project my-proj \
  --instance test-instance \
  --database haikuo-test-db \
  --metadata-instance test-instance \
  --metadata-database haikuo-test-md-db \
  --change-stream-name ChangeStreamSingers \
  --gcs-bucket haikuo-connector-test \
  --big-query-dataset haikuo_connector_test \
  --big-query-table-name singers-changelog \
  --region us-central1
```

Insert a row to Spanner Singers table:
```
gcloud spanner databases execute-sql haikuo-test-db --instance=test-instance --sql='INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (8, "Davlid", "Wang");'
```

Wait for the data to be processed, and then you will be able to see the replicated row in singers-changelog table.
